### PR TITLE
Add redis-om-python

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ Open source Kubernetes troubleshooting and automation platform.
 
 Asynchronous ODM(Object Document Mapper) for MongoDB based on standard python type hints. It's built on top of pydantic for model definition and validation.
 
+## [Redis-OM-Python](https://github.com/redis/redis-om-python) - 317 ✨
+
+Redis OM Python makes it easy to model Redis data in your Python applications.
+
 ## [Djantic](https://github.com/jordaneremieff/djantic) - 263 ✨
 
 Pydantic model support for Django.


### PR DESCRIPTION
Add `Redis OM Python` lib, Redis OM uses [Pydantic](https://github.com/samuelcolvin/pydantic) to validate data based on the type annotations you assign to fields in a model class.