### PR TITLE
Starlite → Litestar

### DIFF
--- a/awesome.yaml
+++ b/awesome.yaml
@@ -149,8 +149,8 @@ repositories:
     description: An admin interface powered by Pydantic. Automatically generate forms using Pydantic models.
     category: Web
 
-  - name: Starlite
-    repo: https://github.com/Goldziher/starlite
+  - name: Litestar (before Starlite)
+    repo: https://github.com/litestar-org/litestar
     description: Flexible ASGI API framework built on top of Starlette and pydantic.
     category: Web
 


### PR DESCRIPTION
Thank you for this awesome curation!

I found Starlite is renamed to Litestar, so send this pull request.
ref: https://litestar.dev/about/organization.html#litestar-and-starlite
>After careful considerations, it was decided that from version 2.0 onwards, Starlite would be renamed and the name Litestar was chosen.
