### PR TITLE
Include `Instructor` in Awesome Pydantic

### DIFF
--- a/awesome.yaml
+++ b/awesome.yaml
@@ -234,3 +234,9 @@ repositories:
     repo: https://github.com/Neoteroi/BlackSheep
     description: BlackSheep is an asynchronous web framework to build event based web applications with Python. It is inspired by Flask, ASP.NET Core, and the work by Yury Selivanov.
     category: Web
+
+  - repo: https://github.com/jxnl/instructor
+    category: Machine Learning
+    # optional
+    name: Instructor
+    description: Controlling OpenAI Function Calling via Pydantic Models


### PR DESCRIPTION
I recently gave a talk on the topic if you're curious: https://www.youtube.com/watch?v=yj-wSRJwrrc

But generally this library allows pydantic to control and prompt openai's gpt, not sure if thats utilities or machine learning.

```python
from openai import OpenAI
import instructor

# Enables `response_model`
client = instructor.patch(OpenAI())

class UserDetail(BaseModel):
    name: str
    age: int

user = client.chat.completions.create(
    model="gpt-3.5-turbo",
    response_model=UserDetail,
    messages=[
        {"role": "user", "content": "Extract Jason is 25 years old"},
    ]
)

assert isinstance(user, UserDetail)
assert user.name == "Jason"
assert user.age == 25
```