### PR TITLE
Add abx-pkg and abxbus 

### DIFF
--- a/awesome.yaml
+++ b/awesome.yaml
@@ -338,3 +338,13 @@ repositories:
     category: Utilities
     name: env-example
     description: A command line tool for creating a .env.example file for all Pydantic settings classes in your project.
+
+  - name: bubus
+    repo: https://github.com/pirate/bbus
+    description: A fast, production-ready event bus that works across Python and JS using Pydantic and Zod.
+    category: Object Mapping
+    
+  - name: abx-pkg
+    repo: https://github.com/ArchiveBox/abx-pkg
+    description: Declare and install runtime package dependencies with pkg managers like apt/brew/npm/pip/cargo using Pydantic.
+    category: Utilities

--- a/awesome.yaml
+++ b/awesome.yaml
@@ -340,7 +340,7 @@ repositories:
     description: A command line tool for creating a .env.example file for all Pydantic settings classes in your project.
 
   - name: bubus
-    repo: https://github.com/pirate/bbus
+    repo: https://github.com/ArchiveBox/abxbus
     description: A fast, production-ready event bus that works across Python and JS using Pydantic and Zod.
     category: Object Mapping
     


### PR DESCRIPTION
Thanks for making this list!

Note I put `abx-pkg` under Utilities because package / dependency management seems more like a "utility" to me, even though it's sort of a type of object mapper / ORM as well. 

I put `abxbus` solidly under object mapping because `Events` are objects in the more traditional sense, and because they are exchanged between Python/JS/various other transport layers, Pydantic is doing the "mapping" of the underlying JSON transit format into a typed Pydantic equivalent interface in python. Arguably it could be a utility though, up to you.