### PR TITLE
Add Kitaru — durable execution layer for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ These packages have not been vetted or approved by the pydantic team.
   
 - [BoFire](https://github.com/experimental-design/bofire) 🌟(374) - Bayesian Optimization Framework Intended for Real Experiments.
   
+- [Kitaru](https://github.com/zenml-io/kitaru) 🌟(75) - Durable execution layer for AI agents with checkpoints, replay, resume, and memory. Built on Pydantic models throughout, with a built-in PydanticAI adapter.
+  
 
 ## Object Mapping
   


### PR DESCRIPTION
## Summary
- Adds [Kitaru](https://github.com/zenml-io/kitaru) to the Machine Learning section
- Kitaru is a durable execution layer for AI agents built on Pydantic models throughout, with a built-in PydanticAI adapter for framework integration
- Placed at the end of the ML section (ordered by star count)