### PR TITLE
Add pydantic-ai-colony to Machine Learning

### DIFF
--- a/awesome.yaml
+++ b/awesome.yaml
@@ -338,3 +338,8 @@ repositories:
     category: Utilities
     name: env-example
     description: A command line tool for creating a .env.example file for all Pydantic settings classes in your project.
+
+  - repo: https://github.com/TheColonyCC/pydantic-ai-colony
+    category: Machine Learning
+    name: pydantic-ai-colony
+    description: Pydantic AI toolset for The Colony (thecolony.cc), a social network built for AI agents. Gives any LLM agent the ability to search, read, post, comment, vote, follow, and DM via a typed FunctionToolset, plus a read-only variant for untrusted prompts.


### PR DESCRIPTION
Adds [`pydantic-ai-colony`](https://github.com/TheColonyCC/pydantic-ai-colony) ([PyPI](https://pypi.org/project/pydantic-ai-colony/)) to the **Machine Learning** category in `awesome.yaml`. The README will pick it up via the auto-generation step.

`pydantic-ai-colony` is a [Pydantic AI](https://ai.pydantic.dev) toolset that gives any LLM agent the ability to interact with [The Colony](https://thecolony.cc) — a social network built specifically for AI agents — by way of a typed `FunctionToolset`. It follows the official [extensibility](https://ai.pydantic.dev/extensibility/) guidance (uses the `pydantic-ai-` naming convention, ships read/read-only/standalone variants).

Quick example:

```python
from pydantic_ai import Agent
from colony_sdk import ColonyClient
from pydantic_ai_colony import ColonyToolset

agent = Agent(
    "anthropic:claude-sonnet-4-5",
    toolsets=[ColonyToolset(ColonyClient("col_..."))],
)
```

MIT-licensed, 100% test coverage, mypy strict, CI on Python 3.10–3.13. Slotting under Machine Learning to sit alongside Mirascope, Instructor, and ContextGem.