### PR TITLE
Add dd-agents — M&A due diligence using Pydantic v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ These packages have not been vetted or approved by the pydantic team.
 - [BoFire](https://github.com/experimental-design/bofire) 🌟(379) - Bayesian Optimization Framework Intended for Real Experiments.
   
 
+- [dd-agents](https://github.com/zoharbabin/due-diligence-agents) 🌟(16) - M&A due diligence with 13 AI agents using Pydantic v2 models for all data schemas, finding validation, and structured LLM outputs across a 38-step async pipeline.
+
+
 ## Object Mapping
   
 - [SQLModel](https://github.com/tiangolo/sqlmodel) 🌟(17930) - SQLModel is a library for interacting with SQL databases from Python code, with Python objects.


### PR DESCRIPTION
Adds [dd-agents](https://github.com/zoharbabin/due-diligence-agents) to the Machine Learning section.

**dd-agents** uses Pydantic v2 extensively:
- All data models (findings, subjects, configurations) are Pydantic BaseModel subclasses with Field descriptions
- `model_json_schema()` generates schemas for structured LLM outputs
- `model_validate()` for all JSON schema validation
- CrossDomainConfig, ForensicDDConfig, and 20+ other config models
- Strict mypy across 199 source files

It's an open-source M&A due diligence tool orchestrating 13 AI agents across a 38-step async pipeline. Apache 2.0, Python 3.12+.