### PR TITLE
docs: add Schemato — schema-to-Pydantic converter

### DIFF
--- a/awesome.yaml
+++ b/awesome.yaml
@@ -338,3 +338,8 @@ repositories:
     category: Utilities
     name: env-example
     description: A command line tool for creating a .env.example file for all Pydantic settings classes in your project.
+
+  - repo: https://github.com/weitaishan/schemato
+    category: Utilities
+    name: Schemato
+    description: Browser-only converter that turns JSON, JSON Schema, OpenAPI 3.x, SQL DDL, Protobuf, Prisma, Mongoose, Avro, GraphQL SDL, and TypeScript interfaces into Pydantic v2 models.


### PR DESCRIPTION
Adding [Schemato](https://www.schemato.top) to the list.

It's a free, open-source, browser-only converter that targets Pydantic v2 from 10 input formats (JSON, JSON Schema, OpenAPI 3.x, SQL DDL, Protobuf, Prisma, Mongoose, Avro, GraphQL SDL, TypeScript).

Most useful entry for Pydantic users:
- https://www.schemato.top/json-schema-to-pydantic
- https://www.schemato.top/openapi-to-pydantic

Disclosure: I'm the maintainer.

Repo: https://github.com/weitaishan/schemato (MIT)