### PR TITLE
Add pydantic-ai-ejentum to Machine Learning category

### DIFF
--- a/awesome.yaml
+++ b/awesome.yaml
@@ -343,3 +343,8 @@ repositories:
     category: Utilities
     name: Schemato
     description: Browser-only converter that turns JSON, JSON Schema, OpenAPI 3.x, SQL DDL, Protobuf, Prisma, Mongoose, Avro, GraphQL SDL, and TypeScript interfaces into Pydantic v2 models.
+
+  - repo: https://github.com/ejentum/pydantic-ai-ejentum
+    category: Machine Learning
+    name: pydantic-ai-ejentum
+    description: PydanticAI Toolset wrapping the Ejentum Reasoning Harness. EjentumToolset subclasses FunctionToolset and registers four agent-callable tools (harness_reasoning, harness_code, harness_anti_deception, harness_memory) the agent calls before generating; each returns a structured cognitive scaffold the model reads internally to shape its next response.


### PR DESCRIPTION
Adds `pydantic-ai-ejentum` to `awesome.yaml` under the **Machine Learning** category.

`pydantic-ai-ejentum` wraps the Ejentum Reasoning Harness as a `FunctionToolset` subclass for PydanticAI agents. `EjentumToolset` registers four agent-callable tools (`harness_reasoning`, `harness_code`, `harness_anti_deception`, `harness_memory`); each call returns a structured cognitive scaffold (named failure pattern, executable procedure, suppression vectors, falsification test) the model reads internally before producing its user-facing answer.

- PyPI: https://pypi.org/project/pydantic-ai-ejentum/ (live)
- Source: https://github.com/ejentum/pydantic-ai-ejentum
- Pydantic AI maintainer added a companion docs entry: https://github.com/pydantic/pydantic-ai/pull/5594
- License: MIT
- Tests: 21/21 unit tests, Python 3.10/3.11/3.12 matrix, OIDC trusted-publisher provenance attestation

Format follows existing entries in awesome.yaml (repo / category / name / description). YAML parses cleanly (verified with PyYAML).