### PR TITLE
Add book-mash and mash-core

### DIFF
--- a/awesome.yaml
+++ b/awesome.yaml
@@ -343,3 +343,13 @@ repositories:
     category: Utilities
     name: Schemato
     description: Browser-only converter that turns JSON, JSON Schema, OpenAPI 3.x, SQL DDL, Protobuf, Prisma, Mongoose, Avro, GraphQL SDL, and TypeScript interfaces into Pydantic v2 models.
+
+  - repo: https://github.com/isatimur/book-mash
+    category: Machine Learning
+    name: book-mash
+    description: A multi-judge LLM measurement engine for book manuscripts. Six judges score prose on craft (humanness, voice, usefulness) and epistemic (evidence density, claim defensibility, redundancy) dimensions, built on pydantic-ai.
+
+  - repo: https://github.com/isatimur/mash-core
+    category: Machine Learning
+    name: mash-core
+    description: Provider-agnostic LLM-judge core built on pydantic-ai, providing the JudgeDim/JudgeScore contract, cost-aware model routing across Anthropic, OpenRouter, and OpenAI-compatible providers, and retry-with-backoff for judge calls.


### PR DESCRIPTION
Adds two related, MIT-licensed projects built on pydantic-ai/pydantic:

- [book-mash](https://github.com/isatimur/book-mash) — a multi-judge LLM measurement engine for book manuscripts (six judges scoring craft and epistemic dimensions).
- [mash-core](https://github.com/isatimur/mash-core) — the provider-agnostic LLM-judge core extracted out of book-mash so a second consumer can reuse it (JudgeDim/JudgeScore contract, cost-aware model routing, retry-with-backoff).

Both under Machine Learning per the existing category set.